### PR TITLE
Extend arena-simulation-setup with arena-models and script to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+This is an Arena-sim-setup rep with extending folder for arena-models and script to download
+## Installation
+Step 1: Clone this repository
+Step 2: Install the DB and the models
+```
+chmod +x down_db_asset.sh
+./down_db_asset.sh
+```

--- a/down_db_asset.sh
+++ b/down_db_asset.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Check if gdown is installed
+if ! command -v gdown &> /dev/null
+then
+    echo "gdown could not be found, installing now..."
+    pip install gdown
+fi
+
+# Download the file using gdown
+echo "Downloading file from Google Drive..."
+gdown https://drive.google.com/drive/u/1/folders/154WwCZ7o7PytpcrFcsndX25gezJ4otx5 -O ./arena_models --folder
+unzip './arena_models/*.zip' -d './arena_models'
+rm ./arena_models/*.zip
+
+echo "Download completed!"

--- a/down_db_asset.sh
+++ b/down_db_asset.sh
@@ -14,3 +14,11 @@ unzip './arena_models/*.zip' -d './arena_models'
 rm ./arena_models/*.zip
 
 echo "Download completed!"
+
+# Extracting Asset bundles
+echo "Replacing Asset bundles in ../arena-unity/Assets/StreamingAssets/StandaloneLinux64"
+rm --recursive --force ../arena-unity/Assets/StreamingAssets/StandaloneLinux64/
+tar -xzf ./arena_models/StandaloneLinux64.tar.gz -C ../arena-unity/Assets/StreamingAssets/
+rm ./arena_models/StandaloneLinux64.tar.gz
+
+echo "Done!"

--- a/down_db_asset.sh
+++ b/down_db_asset.sh
@@ -10,15 +10,17 @@ fi
 # Download the file using gdown
 echo "Downloading file from Google Drive..."
 gdown https://drive.google.com/drive/u/1/folders/154WwCZ7o7PytpcrFcsndX25gezJ4otx5 -O ./arena_models --folder
+echo "Replacing databse in ../arena_models/database"
+rm --recursive --force ../arena_models/database
+rm --recursive --force ../arena_models/Previews
 unzip './arena_models/*.zip' -d './arena_models'
 rm ./arena_models/*.zip
 
 echo "Download completed!"
 
 # Extracting Asset bundles
-echo "Replacing Asset bundles in ../arena-unity/Assets/StreamingAssets/StandaloneLinux64"
-rm --recursive --force ../arena-unity/Assets/StreamingAssets/StandaloneLinux64/
-tar -xzf ./arena_models/StandaloneLinux64.tar.gz -C ../arena-unity/Assets/StreamingAssets/
+echo "Replacing Asset bundles in ../arena_models/arena-unity/Assets/StreamingAssets/StandaloneLinux64"
+tar -xzf ./arena_models/StandaloneLinux64.tar.gz -C ./arena_models
 rm ./arena_models/StandaloneLinux64.tar.gz
 
 echo "Done!"


### PR DESCRIPTION
Download from ggdrive and create a arena-models subfolder to store the database, assetbundles, and previews